### PR TITLE
desktopApp update for readalongs v0.2.20220126

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ conda create --name readalongsDesktop python=3.7
 source activate readalongsDesktop
 ```
 
+On Windows, install `ffmpeg` and `qt` using conda:
+
+```bash
+conda install ffmpeg
+conda install qt
+```
+
+On other systems, install `ffmpeg` and `qt` using your standard package manager.
+
 ### 1. Git clone and install packages
 
 ```bash
@@ -45,14 +54,20 @@ cd ReadalongsDesktop
 pip install -r requirements.txt
 ```
 
-### 2. Pick a Qt library to install:
+### 2. Pick a Qt bindings library to install:
 
-For licensing reason, the user will need to pick their own qt library to install in the same python environment, the common options are pyqt4, pyqt5, pyside2, and pyside6.
+For licensing reason, the user will need to pick their own Qt bindings library to install in the same python environment, the common options are pyqt4, pyqt5, pyside2, and pyside6.
 
 For example, you can install pyqt5 with:
 
 ```bash
 pip install PyQt5
+```
+
+or
+
+```bash
+conda install pyqt5
 ```
 
 At this point, you shall be able to run the GUI app on your local machine with:

--- a/desktopApp.py
+++ b/desktopApp.py
@@ -16,7 +16,7 @@ from qtpy.QtGui import QFont
 
 from readalongs.align import create_input_tei, align_audio
 from readalongs.text.util import save_txt, save_xml, save_minimal_index_html
-from readalongs.util import getLangs, parse_g2p_fallback
+from readalongs.util import getLangs
 from readalongs.log import LOGGER
 
 HOST = "127.0.0.1"
@@ -112,7 +112,7 @@ class readalongsUI(QMainWindow):
             "save_temps": False,
             "text_grid": False,
             "output_xhtml": False,
-            "g2p_fallback": None,
+            "g2p_fallbacks": ["und"],
             "g2p_verbose": False,
         }
 
@@ -268,7 +268,7 @@ class readalongsUI(QMainWindow):
         if self.config["textfile"].split(".")[-1] == "txt":
             tempfile, xml_textfile = create_input_tei(
                 input_file_name=self.config["textfile"],
-                text_language=self.config["language"],
+                text_languages=[self.config["language"], *self.config["g2p_fallbacks"]],
                 save_temps=temp_base,
             )
         elif self.config["textfile"].split(".")[-1] == "xml":
@@ -283,7 +283,6 @@ class readalongsUI(QMainWindow):
             bare=self.config["bare"],
             config=self.config["config"],
             save_temps=temp_base,
-            g2p_fallbacks=parse_g2p_fallback(self.config["g2p_fallback"]),
             verbose_g2p_warnings=self.config["g2p_verbose"],
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-# -e git+https://github.com/roedoejet/g2p.git@841618d2d1fa8b42b36f3f5984dec6cdf51bf98d#egg=g2p
-# -e git+https://github.com/ReadAlongs/Studio.git@f05ef05b295c1571befc3c6eb8aea1aeda48d986#egg=readalongs
+readalongs>=0.2.20220126
 qtpy==1.11.2


### PR DESCRIPTION
 - adjust `desktopApp.py` to the state of readalongs code in the last release
 - update `requirements.txt` to ask for `readalongs>=v0.2.20220126`
 - document that ffmpeg and qt have to be installed separately
