### PR TITLE
Refactor alignment code duplicated between Studio and Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ conda create --name readalongsDesktop python=3.7
 source activate readalongsDesktop
 ```
 
+On Windows, install `ffmpeg` and `qt` using conda:
+
+```bash
+conda install ffmpeg
+conda install qt
+```
+
+On other systems, install `ffmpeg` and `qt` using your standard package manager.
+
 ### 1. Git clone and install packages
 
 ```bash
@@ -45,14 +54,20 @@ cd ReadalongsDesktop
 pip install -r requirements.txt
 ```
 
-### 2. Pick a Qt library to install:
+### 2. Pick a Qt bindings library to install:
 
-For licensing reason, the user will need to pick their own qt library to install in the same python environment, the common options are pyqt4, pyqt5, pyside2, and pyside6.
+For licensing reason, the user will need to pick their own Qt bindings library to install in the same python environment, the common options are pyqt4, pyqt5, pyside2, and pyside6.
 
 For example, you can install pyqt5 with:
 
 ```bash
 pip install PyQt5
+```
+
+or
+
+```bash
+conda install pyqt5
 ```
 
 At this point, you shall be able to run the GUI app on your local machine with:

--- a/desktopApp.py
+++ b/desktopApp.py
@@ -14,9 +14,10 @@ from qtpy.QtGui import QFont
 
 # from qtpy.uic import loadUi
 
+import readalongs.api
 from readalongs.align import create_input_tei, align_audio
 from readalongs.text.util import save_txt, save_xml, save_minimal_index_html
-from readalongs.util import getLangs
+from readalongs.util import get_langs
 from readalongs.log import LOGGER
 
 HOST = "127.0.0.1"
@@ -101,17 +102,12 @@ class readalongsUI(QMainWindow):
             "audiofile": "",
             "xmlfile": "",
             "tokfile": "",
-            "text_input": True,
             "force_overwrite": True,
             "output_base": os.path.join(os.getcwd(), "output"),
             "bare": False,
             "config": None,
-            "closed_captioning": False,
-            "debug": True,
             "unit": "w",
             "save_temps": False,
-            "text_grid": False,
-            "output_xhtml": False,
             "g2p_fallbacks": ["und"],
             "g2p_verbose": False,
         }
@@ -164,7 +160,7 @@ class readalongsUI(QMainWindow):
 
         # grab the language dynamically
 
-        langs, lang_names = getLangs()
+        langs, lang_names = get_langs()
         self.mappingOptions = [f"{l} ({lang_names[l]})" for l in langs]
         self.mappingDropDown = QComboBox()
         self.mappingDropDown.addItems(self.mappingOptions)
@@ -263,6 +259,16 @@ class readalongsUI(QMainWindow):
             f"Successfully stopped server. Now you can resubmit new files.")
 
     def align(self):
+        readalongs.api.align(
+            textfile=self.config["textfile"],
+            audiofile=self.config["audiofile"],
+            output_base=self.config["output_base"],
+            language=[self.config["language"], *self.config["g2p_fallbacks"]],
+            force_overwrite=self.config["force_overwrite"],
+            save_temps=self.config["save_temps"],
+        )
+        return
+
         temp_base = None
         # if text, turn to xml first
         if self.config["textfile"].split(".")[-1] == "txt":

--- a/desktopApp.py
+++ b/desktopApp.py
@@ -1,6 +1,5 @@
 import os, sys
 import http.server
-import socketserver
 
 # from PyQt5 import QtCore
 # from PyQt5.QtCore import Qt
@@ -15,10 +14,9 @@ from qtpy.QtGui import QFont
 # from qtpy.uic import loadUi
 
 import readalongs.api
-from readalongs.align import create_input_tei, align_audio
-from readalongs.text.util import save_txt, save_xml, save_minimal_index_html
+# from readalongs.align import create_input_tei
+# from readalongs.text.util import save_xml
 from readalongs.util import get_langs
-from readalongs.log import LOGGER
 
 HOST = "127.0.0.1"
 PORT = 7000
@@ -267,60 +265,6 @@ class readalongsUI(QMainWindow):
             force_overwrite=self.config["force_overwrite"],
             save_temps=self.config["save_temps"],
         )
-        return
-
-        temp_base = None
-        # if text, turn to xml first
-        if self.config["textfile"].split(".")[-1] == "txt":
-            tempfile, xml_textfile = create_input_tei(
-                input_file_name=self.config["textfile"],
-                text_languages=[self.config["language"], *self.config["g2p_fallbacks"]],
-                save_temps=temp_base,
-            )
-        elif self.config["textfile"].split(".")[-1] == "xml":
-            xml_textfile = self.config["textfile"]
-        else:
-            raise TypeError("Only accept a txt file or xml file.")
-
-        results = align_audio(
-            xml_textfile,
-            self.config["audiofile"],
-            unit=self.config["unit"],
-            bare=self.config["bare"],
-            config=self.config["config"],
-            save_temps=temp_base,
-            verbose_g2p_warnings=self.config["g2p_verbose"],
-        )
-
-        # save the files into local address
-        from readalongs.text.make_smil import make_smil
-
-        # LOGGER.info(self.config)
-        # Note: this filename is based on user's text file path.
-        save_filename = self.config.get("filename", "output")
-        tokenized_xml_path = os.path.join(self.config["output_base"],
-                                          save_filename + ".xml")
-        audio_extension = self.config["audiofile"].split(".")[-1]
-        audio_path = os.path.join(self.config["output_base"],
-                                  save_filename + "." + audio_extension)
-        smil = make_smil(os.path.basename(tokenized_xml_path),
-                         os.path.basename(audio_path), results)
-
-        smil_path = os.path.join(self.config["output_base"],
-                                 save_filename + ".smil")
-        save_xml(tokenized_xml_path, results["tokenized"])
-
-        import shutil
-
-        shutil.copy(self.config["audiofile"], audio_path)
-
-        save_txt(smil_path, smil)
-        save_minimal_index_html(
-            os.path.join(self.config["output_base"], "index.html"),
-            os.path.basename(tokenized_xml_path),
-            os.path.basename(smil_path),
-            os.path.basename(audio_path),
-        )
 
     # def prepare(self):
     #     input_file = self.config["textfile"]
@@ -335,44 +279,6 @@ class readalongsUI(QMainWindow):
     #         text_language=self.config["language"],
     #         output_file=out_file,
     #     )
-
-    # def tokenize(self):
-    #     from lxml import etree
-    #     from readalongs.text.tokenize_xml import tokenize_xml
-
-    #     if not self.config.get("tokfile"):
-    #         self.config["tokfile"] = self.config["xmlfile"].replace("prep", "tok")
-    #     xml = etree.parse(self.config["xmlfile"]).getroot()
-    #     xml = tokenize_xml(xml)
-    #     save_xml(self.config["tokfile"], xml)
-
-    # def g2p(self):
-    #     import io
-    #     from lxml import etree
-
-    #     g2p_kwargs = {
-    #         "tokfile": io.BufferedReader(io.FileIO(self.config["tokfile"])),
-    #         "g2pfile": self.config["xmlfile"].replace("prep", "g2p"),
-    #         "g2p_fallback": None,
-    #         "force_overwrite": True,
-    #         "g2p_verbose": False,
-    #         "debug": False,
-    #     }
-    #     g2p_xml = etree.parse(g2p_kwargs["tokfile"]).getroot()
-    #     from readalongs.text.add_ids_to_xml import add_ids
-
-    #     g2p_xml = add_ids(g2p_xml)
-    #     from readalongs.text.convert_xml import convert_xml
-    #     from readalongs.util import parse_g2p_fallback
-
-    #     g2p_xml, valid = convert_xml(
-    #         g2p_xml,
-    #         g2p_fallbacks=parse_g2p_fallback(g2p_kwargs["g2p_fallback"]),
-    #         verbose_warnings=g2p_kwargs["g2p_verbose"],
-    #     )
-    #     from readalongs.text.util import save_xml
-
-    #     save_xml(g2p_kwargs["g2pfile"], g2p_xml)
 
 
 def main():

--- a/desktopApp.py
+++ b/desktopApp.py
@@ -16,7 +16,7 @@ from qtpy.QtGui import QFont
 
 from readalongs.align import create_input_tei, align_audio
 from readalongs.text.util import save_txt, save_xml, save_minimal_index_html
-from readalongs.util import getLangs, parse_g2p_fallback
+from readalongs.util import getLangs
 from readalongs.log import LOGGER
 
 HOST = "127.0.0.1"
@@ -112,7 +112,7 @@ class readalongsUI(QMainWindow):
             "save_temps": False,
             "text_grid": False,
             "output_xhtml": False,
-            "g2p_fallback": None,
+            "g2p_fallbacks": ["und"],
             "g2p_verbose": False,
         }
 
@@ -268,7 +268,7 @@ class readalongsUI(QMainWindow):
         if self.config["textfile"].split(".")[-1] == "txt":
             tempfile, xml_textfile = create_input_tei(
                 input_file_name=self.config["textfile"],
-                text_language=self.config["language"],
+                text_languages=[self.config["language"], *self.config["g2p_fallbacks"]],
                 save_temps=temp_base,
             )
         elif self.config["textfile"].split(".")[-1] == "xml":
@@ -283,7 +283,6 @@ class readalongsUI(QMainWindow):
             bare=self.config["bare"],
             config=self.config["config"],
             save_temps=temp_base,
-            g2p_fallbacks=parse_g2p_fallback(self.config["g2p_fallback"]),
             verbose_g2p_warnings=self.config["g2p_verbose"],
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-# -e git+https://github.com/roedoejet/g2p.git@841618d2d1fa8b42b36f3f5984dec6cdf51bf98d#egg=g2p
-# -e git+https://github.com/ReadAlongs/Studio.git@f05ef05b295c1571befc3c6eb8aea1aeda48d986#egg=readalongs
+readalongs>=0.2.20220126
 qtpy==1.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
-readalongs>=0.2.20220126
+# readalongs>=0.2.20220126
+
+# The new readalongs.api API has just been added here:
+ -e git+https://github.com/ReadAlongs/Studio.git@bb77d3eaa9ceee2fb731804c1fc795ad8c2eb416#egg=readalongs
+
 qtpy==1.11.2


### PR DESCRIPTION
This PR factors out code that is duplicated between Desktop and Studio by creating a new `readalongs.api` module with a function that can be called from Python code rather than just from the command line.

While PR #14 works with the latest release, this PR, which builds on top of it, requires a commit still on a dev branch, but it already shows how it's going to be able to be done once that feature is merged in to Studio.